### PR TITLE
Feat style updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libre-libre-event-editor-table-panel",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Libre Grafana Panel to assign Downtime Event Reasons",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/EventTable.tsx
+++ b/src/EventTable.tsx
@@ -71,30 +71,35 @@ interface StyledTableProps {
 
 export default function StyledTable({ events, setModalData, theme, options }: StyledTableProps): ReactElement {
   const Style = styled.div`
-    table{
-      width:100%
-    }
-    
     .fixed_header{
       table-layout: fixed;
+      width: 100%;
     }
   
     .fixed_header tbody{
-      display:block;
+      display: block;
       width: 100%;
-      overflow: auto;
+      overflow: overlay;
       height: ${options.height - 21}px;
     }
   
-    .fixed_header thead tr {
-      display: block;
+    .header_row{
+      display: flex;
+      color: #33A2E5;
+      width: 100%;
     }
-  
-  
-    .fixed_header th, .fixed_header td {
+
+    .fixed_header th{
+      width: 14.2857143%;
       text-align: left;
-      padding-left: 5px;
-      width: 300px;
+      padding: 6px;
+      border: 1px solid #9a9a9a;
+    }
+     
+    .fixed_header td{
+      width: 14.2857143%;
+      text-align: left;
+      padding: 6px;
       border: 1px solid #9a9a9a;
     }
 
@@ -112,10 +117,6 @@ export default function StyledTable({ events, setModalData, theme, options }: St
   const columns = React.useMemo(
     () => [
       {
-        Header: 'PackML State',
-        accessor: 'packmlstate',
-      },
-      {
         Header: 'Start',
         accessor: 'start',
       },
@@ -128,6 +129,10 @@ export default function StyledTable({ events, setModalData, theme, options }: St
         accessor: 'duration',
       },
       {
+        Header: 'PackML State',
+        accessor: 'packmlstate',
+      },
+      {
         Header: 'Time Category',
         accessor: 'timeCategory',
       },
@@ -138,7 +143,7 @@ export default function StyledTable({ events, setModalData, theme, options }: St
       {
         Header: 'Comment',
         accessor: 'comment',
-      },
+      }
     ],
     []
   );

--- a/src/EventTable.tsx
+++ b/src/EventTable.tsx
@@ -79,28 +79,35 @@ export default function StyledTable({ events, setModalData, theme, options }: St
     .fixed_header tbody{
       display: block;
       width: 100%;
-      overflow: overlay;
-      height: ${options.height - 21}px;
+      overflow-y: auto;
+      overflow-x: hidden;
+      height: ${options.height - 35}px;
     }
   
     .header_row{
       display: flex;
+      background: ${theme.type == 'dark' ? 'rgb(34, 37, 43)' : 'rgb(244, 245, 245)'};
       color: #33A2E5;
       width: 100%;
     }
 
-    .fixed_header th{
-      width: 14.2857143%;
+    .fixed_header th, .fixed_header td{
+      width: ${options.width / 7}px;
       text-align: left;
       padding: 6px;
-      border: 1px solid #9a9a9a;
+      border-right: ${theme.type == 'dark' ? '1px solid rgba(204, 204, 220, 0.07)' : '1px solid rgba(36, 41, 46, 0.12)'};
     }
-     
-    .fixed_header td{
-      width: 14.2857143%;
-      text-align: left;
-      padding: 6px;
-      border: 1px solid #9a9a9a;
+
+    .fixed_header th:last-child, .fixed_header td:last-child{
+      border-right: none;
+    }
+
+    .fixed_header td:last-child{
+      width: ${(options.width / 7) - 7}px;
+    }
+
+    .fixed_header tr{
+      border-bottom: ${theme.type == 'dark' ? '1px solid rgba(204, 204, 220, 0.07)' : '1px solid rgba(36, 41, 46, 0.12)'};
     }
 
     tr {


### PR DESCRIPTION
### ADD
 - Width and padding specification for the table header and body
 
### CHANGE
 - Display of header from block to flex
 - Color to the header text to match Grafana table
 - Reordered the headers to match previous table
 - Properties specific for the header row based on className instead of stepping through the whole table into the row

### REMOVED
 - Unnecessary table properties when the class name for the table was already created in the style area
 - Commas that followed some properties when there was nothing to follow